### PR TITLE
Add feature of 'let's go home'

### DIFF
--- a/static/js/index.js
+++ b/static/js/index.js
@@ -142,5 +142,8 @@ document.onkeydown = (e) => {
     move(1, 0);
   } else if (e.keyCode == "90") {
     zoomMaze();
+  } else if (e.keyCode == '32') {
+    x = 0; y = 0; 
+    maze.renderPlayer(x, y);
   }
 };


### PR DESCRIPTION
I add a feature in `static/js/index.js` that can help players to go back to their original spot by simply clicking their `space key`. 

When I was playing with the infinite maze, I always feel that the maze was too big that sometimes if you keep going in a single direction too far, it is hard to go back to the original spot and explore another direction. 

To solve this, I create a feature that allows players to go back to the original spot immediately so that they are able to explore every direction of the maze easily. 