### PR TITLE
Assume MG is functional when re-added

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,1 @@
-FLASK_ENV=development
+FLASK_ENV=production

--- a/app.py
+++ b/app.py
@@ -213,6 +213,10 @@ def add_maze_generator():
         if not ALLOW_DELETE_MAZE:
             return "The current server settings does not allow MGs to be modified.", 401
 
+        # assume MG is good
+        data['status'] = STATUS_OK
+        data['message'] = ''
+
         status, message = server_manager.update(mg_name, data)
 
         print(server_manager.servers)


### PR DESCRIPTION
This seems to fix #29; the middleware will assume MGs trying to re-add themselves are functional. If not, they'll just get marked as broken when the next `/generate` request is sent.